### PR TITLE
Comment out types for <

### DIFF
--- a/grammars/kotlin.cson
+++ b/grammars/kotlin.cson
@@ -127,18 +127,18 @@
             }
           ]
         }
-        {
-          begin: "\\w+<"
-          end: ">"
-          patterns: [
-            {
-              include: "#types"
-            }
-            {
-              include: "#keywords"
-            }
-          ]
-        }
+        #{
+        #  begin: "\\w+<"
+        #  end: ">"
+        #  patterns: [
+        #    {
+        #      include: "#types"
+        #    }
+        #    {
+        #      include: "#keywords"
+        #    }
+        #  ]
+        #}
         {
           begin: "(#)\\("
           beginCaptures:


### PR DESCRIPTION
Fixes syntax highlighting after the use of < without spaces for cases such as:
if (1< 2){

}
if (1<2){
  
}